### PR TITLE
libxml++: provide -lkernelbase for __chkstk

### DIFF
--- a/src/libxml++.mk
+++ b/src/libxml++.mk
@@ -18,9 +18,15 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && CXX="$(TARGET)-g++ -mthreads" ./configure \
+    cd '$(1)' && CXX="$(TARGET)-g++" ./configure \
         $(MXE_CONFIGURE_OPTS) \
         MAKE=$(MAKE)
+
+    # A fix similar to the one in coin.mk: add -lkernelbase to provide __chkstk, the Windows stack probe function.
+    # The most likely cause  of libtool missing it is that __chkstk only guards large stack frames (>1 memory page).
+    # See: https://stackoverflow.com/questions/8400118/what-is-the-purpose-of-the-chkstk-function
+    $(SED) -i 's,^postdeps="-,postdeps="-lkernelbase -,g' '$(1)/libtool'
+    
     $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
 endef


### PR DESCRIPTION
Subj. See `src/libxml++.mk` for details.

Tuning `libtool` so that it picked the correct set of hidden libraries (or, rather, not used `nostdlib` at all, because damn, why?) MAY warrant a separate issue, but given the number of packages affected, its severity would probably be "nice to have".