### PR TITLE
CMake cleanup (no OpenSSL on the host)

### DIFF
--- a/src/cmake.mk
+++ b/src/cmake.mk
@@ -9,7 +9,8 @@ $(PKG)_SUBDIR   := cmake-$($(PKG)_VERSION)
 $(PKG)_FILE     := cmake-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://www.cmake.org/files/v$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
 $(PKG)_TARGETS  := $(BUILD)
-$(PKG)_DEPS     :=
+$(PKG)_DEPS     := openssl
+$(PKG)_DEPS_$(BUILD) :=
 
 define $(PKG)_UPDATE
     echo 'NOTE: Please ensure all cmake packages build after updating with:' >&2;
@@ -25,7 +26,8 @@ define $(PKG)_BUILD_$(BUILD)
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         --prefix='$(PREFIX)/$(TARGET)' \
         --parallel='$(JOBS)' \
-        $(PKG_CONFIGURE_OPTS)
+        $(PKG_CONFIGURE_OPTS) \
+        -- -DCMAKE_USE_OPENSSL=OFF
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef

--- a/src/openssl.mk
+++ b/src/openssl.mk
@@ -11,9 +11,9 @@ $(PKG)_URL      := https://download.pahaze.net/ARM/mxe/OpenSSL/src/MSVC.tar.gz
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_BUILD
-    cp $(PREFIX)/../resources/MSVC-OpenSSL/lib/* $(PREFIX)/$(TARGET)/lib
-	cp -r $(PREFIX)/../resources/MSVC-OpenSSL/include/* $(PREFIX)/$(TARGET)/include
-	cp $(PREFIX)/../resources/MSVC-OpenSSL/bin/* $(PREFIX)/$(TARGET)/bin
+    cp $(PWD)/resources/MSVC-OpenSSL/lib/* $(PREFIX)/$(TARGET)/lib
+	cp -r $(PWD)/resources/MSVC-OpenSSL/include/* $(PREFIX)/$(TARGET)/include
+	cp $(PWD)/resources/MSVC-OpenSSL/bin/* $(PREFIX)/$(TARGET)/bin
 
 	sed 's,%PREFIX%,$(PREFIX)/$(TARGET),' \
 		< '$(SOURCE_DIR)/libcrypto.pc' > '$(PREFIX)/$(TARGET)/lib/pkgconfig/libcrypto.pc'


### PR DESCRIPTION
MXE builds in no-network mode, therefore network access libraries are redundant for host CMake anyway.

Extra: use resources from project root rather than `$(PREFIX)/../` (fixes issues when `./usr` is a symlink, and generally more accurate)